### PR TITLE
匯入資料庫的時陣莫改表

### DIFF
--- a/臺灣言語平臺/正規化團隊模型.py
+++ b/臺灣言語平臺/正規化團隊模型.py
@@ -88,13 +88,10 @@ class 正規化sheet表(models.Model):
         資料表 = self.提著資料表()
         全部資料 = 資料表.get_all_values()
         標題 = 全部資料[0]
-        編輯者的座標 = 標題.index('編輯者(簽名)') + 1
-        for 第幾筆, 一筆 in enumerate(全部資料[1:], start=2):
+        _編輯者的座標 = 標題.index('編輯者(簽名)') + 1
+        for 一筆 in 全部資料[1:]:
             這筆資料 = dict(zip(標題, 一筆))
-            新文本項目 = 正規化sheet表.正規化文本自sheet加轉資料庫(這筆資料)
-            if 新文本項目 is None:
-#                 資料表.update_cell(第幾筆, 編輯者的座標, '')
-                pass
+            _新文本項目 = 正規化sheet表.正規化文本自sheet加轉資料庫(這筆資料)
 
     @staticmethod
     def 新文本自資料庫加入sheet(資料表, 平臺項目):

--- a/臺灣言語平臺/正規化團隊模型.py
+++ b/臺灣言語平臺/正規化團隊模型.py
@@ -88,10 +88,9 @@ class 正規化sheet表(models.Model):
         資料表 = self.提著資料表()
         全部資料 = 資料表.get_all_values()
         標題 = 全部資料[0]
-        _編輯者的座標 = 標題.index('編輯者(簽名)') + 1
         for 一筆 in 全部資料[1:]:
             這筆資料 = dict(zip(標題, 一筆))
-            _新文本項目 = 正規化sheet表.正規化文本自sheet加轉資料庫(這筆資料)
+            正規化sheet表.正規化文本自sheet加轉資料庫(這筆資料)
 
     @staticmethod
     def 新文本自資料庫加入sheet(資料表, 平臺項目):

--- a/臺灣言語平臺/正規化團隊模型.py
+++ b/臺灣言語平臺/正規化團隊模型.py
@@ -93,7 +93,8 @@ class 正規化sheet表(models.Model):
             這筆資料 = dict(zip(標題, 一筆))
             新文本項目 = 正規化sheet表.正規化文本自sheet加轉資料庫(這筆資料)
             if 新文本項目 is None:
-                資料表.update_cell(第幾筆, 編輯者的座標, '')
+#                 資料表.update_cell(第幾筆, 編輯者的座標, '')
+                pass
 
     @staticmethod
     def 新文本自資料庫加入sheet(資料表, 平臺項目):

--- a/試驗/正規化團隊/test正規化文本自sheet加轉資料庫試驗.py
+++ b/試驗/正規化團隊/test正規化文本自sheet加轉資料庫試驗.py
@@ -296,11 +296,7 @@ class 正規化文本自sheet加轉資料庫試驗(TestCase):
         臺語sheet表 = self._加臺語sheet表()
         臺語sheet表.整理到資料庫()
 
-        資料表mocka.update_cell.assert_has_calls([
-            call(2, 10, ''),
-            call(3, 10, ''),
-            call(4, 10, ''),
-        ])
+        資料表mocka.update_cell.assert_not_called()
 
     @patch('gspread.authorize')
     def test_資料有漢字佮拼音簽名愛留咧(self, authorizeMocka):


### PR DESCRIPTION
https://github.com/g0v/itaigi/issues/160 有簽名無去的問題

當初時是想講，若`漢字`佮`音標`有漏勾，就共簽名提掉 #107 
這馬是匯入去的資料，會共因清掉

雖然有法度修好
毋過想講規氣莫改著表
#134 就毋驚有人佇匯入的時陣用
