### PR TITLE
貢獻者詞條項目重覆回傳bug fix

### DIFF
--- a/臺灣言語平臺/介面/貢獻者.py
+++ b/臺灣言語平臺/介面/貢獻者.py
@@ -24,10 +24,8 @@ def 貢獻者表(request):
 
     result = list()
 
-    #for user in map(lambda x: x[1], sorted(contributor_dict.items(),
-    #                key=lambda x: len(x[1]['詞條']), reverse=True)):
     for user in sorted(contributor_dict.values(),
-                key=lambda x: len(x['詞條']), reverse=True):
+                       key=lambda x: len(x['詞條']), reverse=True):
         user['數量'] = len(user['詞條'])
         user['詞條'] = list(set(user['詞條']))
         if len(user['詞條']) > 10:

--- a/臺灣言語平臺/介面/貢獻者.py
+++ b/臺灣言語平臺/介面/貢獻者.py
@@ -24,8 +24,10 @@ def 貢獻者表(request):
 
     result = list()
 
-    for user in map(lambda x: x[1], sorted(contributor_dict.items(),
-                    key=lambda x: len(x[1]['詞條']), reverse=True)):
+    #for user in map(lambda x: x[1], sorted(contributor_dict.items(),
+    #                key=lambda x: len(x[1]['詞條']), reverse=True)):
+    for user in sorted(contributor_dict.values(),
+                key=lambda x: len(x['詞條']), reverse=True):
         user['數量'] = len(user['詞條'])
         user['詞條'] = list(set(user['詞條']))
         if len(user['詞條']) > 10:

--- a/臺灣言語平臺/介面/貢獻者.py
+++ b/臺灣言語平臺/介面/貢獻者.py
@@ -27,7 +27,8 @@ def 貢獻者表(request):
     for user in map(lambda x: x[1], sorted(contributor_dict.items(),
                     key=lambda x: len(x[1]['詞條']), reverse=True)):
         user['數量'] = len(user['詞條'])
-        if user['數量'] > 10:
+        user['詞條'] = list(set(user['詞條']))
+        if len(user['詞條']) > 10:
             user['詞條'] = random.sample(user['詞條'], 10)
         result.append(user)
 

--- a/試驗/貢獻者/test查貢獻者表.py
+++ b/試驗/貢獻者/test查貢獻者表.py
@@ -67,10 +67,7 @@ class 查貢獻者表試驗(TestCase):
         self.assertEqual(外語表.objects.all().count(), self.外語表資料數)
         self.assertEqual(影音表.objects.all().count(), self.影音表資料數)
         self.assertEqual(翻譯影音表.objects.all().count(), self.翻譯影音表資料數)
-        self.assertEqual(文本表.objects.all().count(), self.文本表資料數 + 2)
         self.assertEqual(影音文本表.objects.all().count(), self.影音文本表資料數)
-        self.assertEqual(翻譯文本表.objects.all().count(), self.翻譯文本表資料數 + 1)
-        self.assertEqual(平臺項目表.objects.all().count(), self.平臺項目表資料數 + 2)
 
     def 有對應函式(self):
         對應 = resolve('/貢獻者表')
@@ -100,3 +97,47 @@ class 查貢獻者表試驗(TestCase):
         self.assertEqual(回應Json['名人'][0]['詞條'], ['漂亮'])
         self.assertEqual(回應Json['名人'][0]['數量'], 1)
         self.assertEqual(回應Json['名人'][0]['名'], '貢獻者1號')
+
+        self.assertEqual(文本表.objects.all().count(), self.文本表資料數 + 2)
+        self.assertEqual(翻譯文本表.objects.all().count(), self.翻譯文本表資料數 + 1)
+        self.assertEqual(平臺項目表.objects.all().count(), self.平臺項目表資料數 + 2)
+
+    def test_確認貢獻重覆詞條不同發音會被處理(self):
+
+        貢獻文本資料 = ['水', '生著不醜']
+        貢獻音標資料 = ['suie', 'se-liao-bei-bai']
+
+        正規文本資料 = ['媠', '生做袂䆀']
+        正規音標資料 = ['sui2', 'senn-tsò-bē-bái']
+
+        self.client.force_login(self.貢獻者)
+
+        self.assertEqual(len(貢獻文本資料), len(貢獻音標資料))
+        self.assertEqual(len(正規文本資料), len(正規音標資料))
+
+        for i in range(len(貢獻文本資料)):
+            回應 = self.client.post(
+                '/平臺項目/加新詞文本', {
+                    '外語項目編號': self.外語項目編號,
+                    '文本資料': 貢獻文本資料[i],
+                    '音標資料': 貢獻音標資料[i],
+                }
+            )
+
+            平臺項目編號 = 回應.json()['平臺項目編號']
+            平臺項目 = 平臺項目表.揣編號(平臺項目編號)
+            平臺項目.對正規化sheet校對母語文本(
+                平臺項目編號, '正規化團隊一號團員',
+                正規文本資料[i], 正規音標資料[i]
+            )
+
+        回應 = self.client.get('/貢獻者表')
+        回應Json = 回應.json()
+        self.assertEqual(len(回應Json['名人']), 1)
+        self.assertEqual(回應Json['名人'][0]['詞條'], ['漂亮'])
+        self.assertEqual(回應Json['名人'][0]['數量'], 1)
+        self.assertEqual(回應Json['名人'][0]['名'], '貢獻者1號')
+
+        self.assertEqual(文本表.objects.all().count(), self.文本表資料數 + 4)
+        self.assertEqual(翻譯文本表.objects.all().count(), self.翻譯文本表資料數 + 2)
+        self.assertEqual(平臺項目表.objects.all().count(), self.平臺項目表資料數 + 4)

--- a/試驗/貢獻者/test查貢獻者表.py
+++ b/試驗/貢獻者/test查貢獻者表.py
@@ -135,7 +135,7 @@ class 查貢獻者表試驗(TestCase):
         回應Json = 回應.json()
         self.assertEqual(len(回應Json['名人']), 1)
         self.assertEqual(回應Json['名人'][0]['詞條'], ['漂亮'])
-        self.assertEqual(回應Json['名人'][0]['數量'], 1)
+        self.assertEqual(回應Json['名人'][0]['數量'], 2)
         self.assertEqual(回應Json['名人'][0]['名'], '貢獻者1號')
 
         self.assertEqual(文本表.objects.all().count(), self.文本表資料數 + 4)


### PR DESCRIPTION
在這裡因為可能貢獻者對於一個外語貢獻多種說法，
因說法不同故仍需計算，

如果對於某詞條，貢獻者提供 A & B 兩種說法，
這樣子應該要計算成貢獻條目 = 2

_但是在貢獻者頁會出現兩次外語條目_，此 PR 修復了這個問題
