### PR TITLE
更新我很會頁面詞條排序

### DIFF
--- a/臺灣言語平臺/介面/加資料.py
+++ b/臺灣言語平臺/介面/加資料.py
@@ -76,6 +76,8 @@ def 加外語請教條(request):
     except 種類表.DoesNotExist:
         return 失敗的json回應('種類欄位不符規範')
     except ValidationError as 錯誤:
+        更新時間戳 = 平臺項目表.揣編號(編號=錯誤.平臺項目編號)
+        更新時間戳.save()
         return JsonResponse({
             '其他': '這個外語已經有了',
             '平臺項目編號': str(錯誤.平臺項目編號),

--- a/臺灣言語平臺/項目模型.py
+++ b/臺灣言語平臺/項目模型.py
@@ -30,6 +30,7 @@ class 平臺項目表(models.Model):
     按呢無好 = models.IntegerField(default=0)
     # When value is False, then data will be visible
     愛藏起來 = models.BooleanField(default=False)
+    保存時間 = models.DateTimeField(auto_now=True, editable=True)
 
     def 編號(self):
         return self.pk
@@ -78,7 +79,7 @@ class 平臺項目表(models.Model):
                 Q(平臺項目__愛藏起來=False)
             )
             .distinct()
-            .order_by('-pk')
+            .order_by('-平臺項目__保存時間', '-pk')
         )
 
     @classmethod


### PR DESCRIPTION
`平臺項目表` 增加 `保存時間` 欄位。
使用者查詢已存在的文字時會更新 `保存時間`，並根據這個作為 `我很會` 頁面的排序。
