### PR TITLE
加速貢獻者

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
       - libavcodec-extra-53
 install:
 - pip install django==1.9.8
-- pip install tai5-uan5-gian5-gi2-tsu1-liau7-khoo3 django-allauth==0.25.2 python-dateutil django-cors-headers pyOpenSSL oauth2client gspread celery
+- pip install tai5-uan5-gian5-gi2-tsu1-liau7-khoo3 django-allauth==0.25.2 python-dateutil django-cors-headers pyOpenSSL oauth2client gspread celery==3.1.25
 - pip install behave-django
 - pip install flake8
 - pip install python-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ addons:
       - libavcodec-extra-53
 install:
 - pip install django==1.9.8
-- pip install tai5-uan5-gian5-gi2-tsu1-liau7-khoo3 django-allauth python-dateutil django-cors-headers pyOpenSSL oauth2client gspread celery
+- pip install tai5-uan5-gian5-gi2-tsu1-liau7-khoo3 django-allauth==0.25.2 python-dateutil django-cors-headers pyOpenSSL oauth2client gspread celery
 - pip install behave-django
 - pip install flake8
 - pip install python-coveralls

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,6 @@ setup(
         'pyOpenSSL',
         'oauth2client',
         'gspread',
-        'celery',
+        'celery==3.1.25',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ setup(
     install_requires=[
         'django>=1.9.7',
         'tai5-uan5-gian5-gi2-tsu1-liau7-khoo3>=3.1.12',
-        'django-allauth>=0.25.2',
+        'django-allauth==0.25.2',
         'python-dateutil>=2.4.1',
         'django-cors-headers',
         'pyOpenSSL',

--- a/臺灣言語平臺/介面/貢獻者.py
+++ b/臺灣言語平臺/介面/貢獻者.py
@@ -9,24 +9,21 @@ def 貢獻者表(request):
     # 2 = 臺灣閩南語常用詞辭典, 269 = 台文華文線頂辭典
     contributor_dict = {}
 
-    for 文本 in 文本校對表.objects.all():
+    for 文本 in 文本校對表.objects.prefetch_related('舊文本__來源'):
         # 取出第一層
         來源_id = 文本.舊文本.來源_id
         來源名稱 = 文本.舊文本.來源.名
-        詞條名稱 = 文本.舊文本.來源外語.外語.外語資料
 
         if 來源_id not in contributor_dict:
             contributor_dict[來源_id] = dict()
             contributor_dict[來源_id]['名'] = 來源名稱
-            contributor_dict[來源_id]['詞條'] = list()
-        contributor_dict[來源_id]['詞條'].append(詞條名稱)
+            contributor_dict[來源_id]['數量'] = 0
+        contributor_dict[來源_id]['數量'] += 1
 
     result = list()
 
     for user in sorted(contributor_dict.values(),
-                       key=lambda x: len(x['詞條']), reverse=True):
-        user['數量'] = len(user['詞條'])
-        user.pop('詞條')
+                       key=lambda x: x['數量'], reverse=True):
         if user['名'] == '匿名':
             user['名'] = '沒有人'
         result.append(user)


### PR DESCRIPTION
#170

原本是O(1+4n)的sql
```
    for 文本 in 文本校對表.objects.all():  # 1个sql，得著n个文本校對
        # 取出第一層
        來源_id = 文本.舊文本.來源_id  # n个求`舊文本`的sql
        來源名稱 = 文本.舊文本.來源.名  # 舊文本的sql過矣，n个求`來源`的sql
        詞條名稱 = 文本.舊文本.來源外語.外語.外語資料  # n个`來源外語`的sql+n个`外語`的sql
```
用[prefetch-related](https://docs.djangoproject.com/el/1.10/ref/models/querysets/#prefetch-related)加速，改做O(1)的sql
```
    for 文本 in 文本校對表.objects.prefetch_related('舊文本__來源'):  # 1个sql
        # 取出第一層
        來源_id = 文本.舊文本.來源_id  # prefetch矣
        來源名稱 = 文本.舊文本.來源.名  # prefetch矣
```

毋過我走過試驗爾
你彼爿是用啥物資料來試速度？